### PR TITLE
Add runtime migrations for polkadot-v0.9.42 -> v1.7.0

### DIFF
--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -1,0 +1,76 @@
+name: Check Migrations
+
+on:
+  push:
+    branches: ["develop"]
+  pull_request:
+    branches: ["develop"]
+  workflow_dispatch:
+
+# Cancel a currently running workflow from the same PR, branch or tag when a new workflow is
+# triggered (ref https://stackoverflow.com/a/72408109)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  runtime-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      runtime: ${{ steps.runtime.outputs.runtime }}
+    name: Extract tasks from matrix
+    steps:
+      - uses: actions/checkout@v3
+      - id: runtime
+        run: |
+          # Filter out runtimes that don't have a URI
+          TASKS=$(jq '[.[] | select(.uri != null)]' .github/workflows/runtimes-matrix.json)
+          SKIPPED_TASKS=$(jq '[.[] | select(.uri == null)]' .github/workflows/runtimes-matrix.json)
+          echo --- Running the following tasks ---
+          echo $TASKS
+          echo --- Skipping the following tasks due to not having a uri field ---
+          echo $SKIPPED_TASKS
+          # Strip whitespace from Tasks now that we've logged it
+          TASKS=$(echo $TASKS | jq -c .)
+          echo "runtime=$TASKS" >> $GITHUB_OUTPUT
+
+  check-migrations:
+    needs: [runtime-matrix]
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Download try-runtime-cli
+        run: |
+          curl -sL https://github.com/paritytech/try-runtime-cli/releases/download/v0.5.2/try-runtime-x86_64-unknown-linux-musl -o try-runtime
+          chmod +x ./try-runtime
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: "3.6.1"
+
+      - name: Add wasm32-unknown-unknown target
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Build ${{ matrix.runtime.name }}
+        run: |
+          cargo build --release -p ${{ matrix.runtime.package }} --features try-runtime -q --locked
+
+      - name: Check migrations
+        # Todo: enable spec-version-check dynamically if we are releasing
+        run: |
+          PACKAGE_NAME=${{ matrix.runtime.package }}
+          RUNTIME_BLOB_NAME=$(echo $PACKAGE_NAME | sed 's/-/_/g').compact.compressed.wasm
+          RUNTIME_BLOB_PATH=./target/release/wbuild/$PACKAGE_NAME/$RUNTIME_BLOB_NAME
+
+          ./try-runtime \
+            --runtime $RUNTIME_BLOB_PATH \
+            on-runtime-upgrade --checks=pre-and-post \
+            --disable-spec-version-check --disable-idempotency-checks \
+            live --uri ${{ matrix.runtime.uri }}

--- a/.github/workflows/check-migration.yml
+++ b/.github/workflows/check-migration.yml
@@ -20,7 +20,7 @@ jobs:
       runtime: ${{ steps.runtime.outputs.runtime }}
     name: Extract tasks from matrix
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - id: runtime
         run: |
           # Filter out runtimes that don't have a URI
@@ -43,7 +43,7 @@ jobs:
         runtime: ${{ fromJSON(needs.runtime-matrix.outputs.runtime) }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Download try-runtime-cli
         run: |

--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "ajuna",
+    "package": "ajuna-runtime",
+    "path": "runtime/ajuna-runtime",
+    "uri": "wss://rpc-parachain.ajuna.network:443"
+  }
+]

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -144,10 +144,9 @@ pub type Executive = frame_executive::Executive<
 // entire chain state. However, this is to be expected and can be ignored:
 // https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
 type Migrations = (
-	// We have currently 356 identities on Bajun, so setting the max number to be migrated to 1_000
-	// should be more than enough, while still staying in a limit that will not overweigh our
-	// runtime migration.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, { 1_000 }>,
+	// todo: note amount of identities.
+	// while still staying in a limit that will not overweigh our runtime migration.
+	pallet_identity::migration::versioned::V0ToV1<Runtime, 1_000>,
 	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
 	// hurt either.
 	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -137,7 +137,27 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	Migrations,
 >;
+
+// Note: if try-runtime pre/post checks are enabled it will error when it tries to decode the
+// entire chain state. However, this is to be expected and can be ignored:
+// https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
+type Migrations = (
+	// We have currently 356 identities on Bajun, so setting the max number to be migrated to 1_000
+	// should be more than enough, while still staying in a limit that will not overweigh our
+	// runtime migration.
+	pallet_identity::migration::versioned::V0ToV1<Runtime, { 1_000 }>,
+	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
+	// hurt either.
+	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,
+	// Simple migration ordering the set of invulnerables.
+	pallet_collator_selection::migration::v1::MigrateToV1<Runtime>,
+	// Simple migration of the queue config data.
+	cumulus_pallet_xcmp_queue::migration::v4::MigrationToV4<Runtime>,
+);
+
+//type Migrations = (pallet_ajuna_awesome_avatars::migration::v6::MigrateToV6<Runtime>,);
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the
 /// node's balance type.

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -144,9 +144,6 @@ pub type Executive = frame_executive::Executive<
 // entire chain state. However, this is to be expected and can be ignored:
 // https://substrate.stackexchange.com/questions/10986/runtime-upgrade-for-parachainsystemhostconfiguration
 type Migrations = (
-	// todo: note amount of identities.
-	// while still staying in a limit that will not overweigh our runtime migration.
-	pallet_identity::migration::versioned::V0ToV1<Runtime, 1_000>,
 	// Track inactive funds of the teleporter account, currently we don't use that, but it doesn't
 	// hurt either.
 	pallet_balances::migration::MigrateToTrackInactive<Runtime, xcm_config::CheckingAccount>,

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -49,6 +49,9 @@ parameter_types! {
 	pub const RelayNetwork: Option<NetworkId> = None;
 	pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
 	pub UniversalLocation: InteriorLocation = Parachain(ParachainInfo::parachain_id().into()).into();
+	// Potential KSM teleporter account, we don't teleport (yet). If we also have a
+	// convenience DEX for DOT<>AJUN at some point, we want to teleport.
+	pub CheckingAccount: AccountId = PolkadotXcm::check_account();
 }
 
 /// Type for specifying how a `MultiLocation` can be converted into an `AccountId`. This is used


### PR DESCRIPTION
This also adds some new pallets, which are not on the production chain net, we might consider removing these pallets if we don't intend to go live soon.