### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6023,8 +6023,8 @@ dependencies = [
 
 [[package]]
 name = "orml-pallets-benchmarking"
-version = "0.7.0"
-source = "git+https://github.com/ajuna-network/ajuna-pallets.git?tag=v0.7.0#93863957a91ef3ec199cb09757890a5f3f3d201b"
+version = "0.1.0"
+source = "git+https://github.com/ajuna-network/ajuna-pallets.git?branch=v0.1.0-polkadot-v1.10.0#24b4c3d666af902e8d024e615647ab3f552f0f14"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "ajuna-node"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "ajuna-runtime",
  "async-trait",
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "ajuna-runtime"
-version = "0.4.0-rc1"
+version = "0.4.0"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-parachain-system",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ orml-vesting = { version = "0.10.0", default-features = false }
 ajuna-runtime = { path = "runtime/ajuna" }
 
 # Ajuna Pallets
-orml-pallets-benchmarking                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", tag = "v0.7.0", default-features = false }
+orml-pallets-benchmarking                   = { git = "https://github.com/ajuna-network/ajuna-pallets.git", branch = "v0.1.0-polkadot-v1.10.0", default-features = false }
 
 [profile.production]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors    = [ "Ajuna Network <https://github.com/ajuna-network>" ]
 edition    = "2021"
 homepage   = "https://ajuna.io"
 repository = "https://github.com/ajuna-network/Ajuna"
-version    = "0.4.0-rc1"
+version    = "0.4.0"
 
 [workspace]
 resolver = "2"


### PR DESCRIPTION
I compared the code to what we have deployed on Kusama (v0.4.0-rc1) and it is basically identical except for the missing ajuna-pallets and the Ajun vs. Bajun identifiers. So I suggest merging this one, create a release and upgrade the production runtime here too,