### PR TITLE
Chainspec fixes; replace kusama with polkadot + fix chain-id of ajuna-paseo (need to move de chain-db before deployment)

### DIFF
--- a/node/src/chain_spec_utils.rs
+++ b/node/src/chain_spec_utils.rs
@@ -105,10 +105,10 @@ impl AjunaKeys {
 }
 
 pub enum RelayChain {
-	Kusama,
+	Polkadot,
 	Paseo,
 	Westend,
-	KusamaLocal,
+	PolkadotLocal,
 	PaseoLocal,
 	RococoLocal,
 	WestendLocal,
@@ -117,10 +117,10 @@ pub enum RelayChain {
 impl RelayChain {
 	pub fn id(&self) -> &'static str {
 		match self {
-			RelayChain::Kusama => "kusama",
+			RelayChain::Polkadot => "polkadot",
 			RelayChain::Paseo => "paseo",
 			RelayChain::Westend => "westend",
-			RelayChain::KusamaLocal => "kusama-local",
+			RelayChain::PolkadotLocal => "polkadot-local",
 			RelayChain::PaseoLocal => "paseo-local",
 			RelayChain::RococoLocal => "rococo-local",
 			RelayChain::WestendLocal => "westend-local",
@@ -129,10 +129,10 @@ impl RelayChain {
 
 	pub fn name(&self) -> &'static str {
 		match self {
-			RelayChain::Kusama => "Kusama",
+			RelayChain::Polkadot => "Polkadot",
 			RelayChain::Paseo => "Paseo",
 			RelayChain::Westend => "Westend",
-			RelayChain::KusamaLocal => "Kusama-local",
+			RelayChain::PolkadotLocal => "Polkadot-local",
 			RelayChain::PaseoLocal => "Paseo-local",
 			RelayChain::RococoLocal => "Rococo-local",
 			RelayChain::WestendLocal => "Westend-local",
@@ -141,10 +141,10 @@ impl RelayChain {
 
 	pub(crate) fn chain_type(&self) -> ChainType {
 		match self {
-			RelayChain::Kusama => ChainType::Live,
+			RelayChain::Polkadot => ChainType::Live,
 			RelayChain::Paseo => ChainType::Live,
 			RelayChain::Westend => ChainType::Live,
-			RelayChain::KusamaLocal => ChainType::Local,
+			RelayChain::PolkadotLocal => ChainType::Local,
 			RelayChain::PaseoLocal => ChainType::Local,
 			RelayChain::RococoLocal => ChainType::Local,
 			RelayChain::WestendLocal => ChainType::Local,
@@ -152,10 +152,10 @@ impl RelayChain {
 	}
 	pub(crate) fn protocol_id(&self) -> &str {
 		match self {
-			RelayChain::Kusama => "ajuna-k",
+			RelayChain::Polkadot => "ajuna-k",
 			RelayChain::Paseo => "ajuna-pas",
 			RelayChain::Westend => "ajuna-w",
-			RelayChain::KusamaLocal => "ajuna-kl",
+			RelayChain::PolkadotLocal => "ajuna-kl",
 			RelayChain::PaseoLocal => "ajuna-pasl",
 			RelayChain::RococoLocal => "ajuna-rl",
 			RelayChain::WestendLocal => "ajuna-wl",

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -85,17 +85,17 @@ const LOCAL_PARA_ID: u32 = 2051;
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	Ok(match id {
 		// live configs
-		"ajuna-kusama" => Box::new(ajuna_config()?),
+		"ajuna-polkadot" => Box::new(ajuna_config()?),
 		"ajuna-paseo" => Box::new(ajuna_paseo_config()?),
 		"ajuna-westend" => Box::new(ajuna_westend_config()?),
 
 		// fresh production/testnet chain-specs based on the current rust code
-		"ajuna-kusama-fresh" => Box::new(ajuna_chain_spec(POLKADOT_PARA_ID.into(), GenesisKeys::Ajuna, RelayChain::Kusama)),
+		"ajuna-polkadot-fresh" => Box::new(ajuna_chain_spec(POLKADOT_PARA_ID.into(), GenesisKeys::Ajuna, RelayChain::Polkadot)),
 		"ajuna-paseo-fresh" => Box::new(ajuna_chain_spec(PASEO_PARA_ID.into(), GenesisKeys::TestnetDev, RelayChain::Paseo)),
 		"ajuna-westend-fresh" => Box::new(ajuna_chain_spec(WESTEND_PARA_ID.into(), GenesisKeys::TestnetDev, RelayChain::Westend)),
 
 		// rust code based configs for a local setup
-		"ajuna-kusama-local" => Box::new(ajuna_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::KusamaLocal)),
+		"ajuna-polkadot-local" => Box::new(ajuna_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::PolkadotLocal)),
 		"ajuna-paseo-local" => Box::new(ajuna_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::PaseoLocal)),
 		"ajuna-westend-local" => Box::new(ajuna_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::WestendLocal)),
 		"" | "ajuna-rococo-local" => Box::new(ajuna_chain_spec(LOCAL_PARA_ID.into(), GenesisKeys::WellKnown, RelayChain::RococoLocal)),

--- a/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
@@ -1,16 +1,16 @@
 {
   "name": "Ajuna Paseo",
-  "id": "ajuna-ajuna-westend",
+  "id": "ajuna-paseo",
   "chainType": "Live",
   "bootNodes": [],
   "telemetryEndpoints": null,
-  "protocolId": "ajuna-w",
+  "protocolId": "ajuna-pas",
   "properties": {
     "ss58Format": 1328,
     "tokenDecimals": 12,
     "tokenSymbol": "AJUN"
   },
-  "relay_chain": "ajuna-westend",
+  "relay_chain": "paseo",
   "para_id": 2051,
   "codeSubstitutes": {},
   "genesis": {

--- a/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
@@ -3,8 +3,8 @@
   "id": "ajuna-paseo",
   "chainType": "Live",
   "bootNodes": [
-    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
-    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+    "/ip4/95.217.105.80/tcp/23804/p2p/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/23804/p2p/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
   ],
   "telemetryEndpoints": null,
   "protocolId": "ajuna-pas",

--- a/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw-unsorted.json
@@ -2,7 +2,10 @@
   "name": "Ajuna Paseo",
   "id": "ajuna-paseo",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+  ],
   "telemetryEndpoints": null,
   "protocolId": "ajuna-pas",
   "properties": {

--- a/resources/ajuna/paseo/ajuna-paseo-raw.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw.json
@@ -75,7 +75,7 @@
       }
     }
   },
-  "id": "ajuna-ajuna-westend",
+  "id": "ajuna-paseo",
   "name": "Ajuna Paseo",
   "para_id": 2051,
   "properties": {
@@ -83,7 +83,7 @@
     "tokenDecimals": 12,
     "tokenSymbol": "AJUN"
   },
-  "protocolId": "ajuna-w",
-  "relay_chain": "ajuna-westend",
+  "protocolId": "ajuna-pas",
+  "relay_chain": "paseo",
   "telemetryEndpoints": null
 }

--- a/resources/ajuna/paseo/ajuna-paseo-raw.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw.json
@@ -1,7 +1,7 @@
 {
   "bootNodes": [
-    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
-    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+    "/ip4/95.217.105.80/tcp/23804/p2p/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/23804/p2p/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
   ],
   "chainType": "Live",
   "codeSubstitutes": {},

--- a/resources/ajuna/paseo/ajuna-paseo-raw.json
+++ b/resources/ajuna/paseo/ajuna-paseo-raw.json
@@ -1,5 +1,8 @@
 {
-  "bootNodes": [],
+  "bootNodes": [
+    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+  ],
   "chainType": "Live",
   "codeSubstitutes": {},
   "genesis": {

--- a/resources/ajuna/paseo/ajuna-paseo.json
+++ b/resources/ajuna/paseo/ajuna-paseo.json
@@ -1,16 +1,16 @@
 {
   "name": "Ajuna Paseo",
-  "id": "ajuna-ajuna-westend",
+  "id": "ajuna-paseo",
   "chainType": "Live",
   "bootNodes": [],
   "telemetryEndpoints": null,
-  "protocolId": "ajuna-w",
+  "protocolId": "ajuna-pas",
   "properties": {
     "ss58Format": 1328,
     "tokenDecimals": 12,
     "tokenSymbol": "AJUN"
   },
-  "relay_chain": "ajuna-westend",
+  "relay_chain": "paseo",
   "para_id": 2051,
   "codeSubstitutes": {},
   "genesis": {

--- a/resources/ajuna/paseo/ajuna-paseo.json
+++ b/resources/ajuna/paseo/ajuna-paseo.json
@@ -2,7 +2,10 @@
   "name": "Ajuna Paseo",
   "id": "ajuna-paseo",
   "chainType": "Live",
-  "bootNodes": [],
+  "bootNodes": [
+    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+  ],
   "telemetryEndpoints": null,
   "protocolId": "ajuna-pas",
   "properties": {

--- a/resources/ajuna/paseo/ajuna-paseo.json
+++ b/resources/ajuna/paseo/ajuna-paseo.json
@@ -3,8 +3,8 @@
   "id": "ajuna-paseo",
   "chainType": "Live",
   "bootNodes": [
-    "/ip4/95.217.105.80/tcp/16809/ws/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
-    "/ip4/135.181.240.254/tcp/16809/ws/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
+    "/ip4/95.217.105.80/tcp/23804/p2p/12D3KooWFR6k9RLLRUJDhS8R4a2s7c8Tc1t2Rf7d7WGn9K2XpNsB",
+    "/ip4/135.181.240.254/tcp/23804/p2p/12D3KooWLRzxpDsfbgZPVM3719JQ1Xct5jg3En7ANJZ2ntRfYo7x"
   ],
   "telemetryEndpoints": null,
   "protocolId": "ajuna-pas",


### PR DESCRIPTION
I introduced some error in the chain-spec due to copy-pasting.

* I introduced Kusama in some places due to copying code from our bajun-parachain repository
* I introduced some errors in our paseo-chainspec because I copied it from the westend one and forgot to replace some westend specific stuff.

 **NOTE**: before deployment of the new ajuna-paseo docker images we have to:
* Stop the docker container
* copy the `ajuna-paseo/chains/ajuna-ajuna-westend` to `ajuna-paseo/chains/ajuna-paseo`
* start the service with the new docker images (I tested locally that this works)