### PR TITLE
add `CheckMetadataHash` signed extension 

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -19,9 +19,10 @@ on:
       # Matches tags containing an arbitrary suffix starting with '-'.
       - v[0-9]+.[0-9]+.[0-9]+-*
 
-# Ensures only one build is run per branch, unless pushing to develop
+# Cancel a currently running workflow from the same PR, branch or tag when a new workflow is
+# triggered (ref https://stackoverflow.com/a/72408109)
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/develop' && github.run_number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -105,6 +105,8 @@ jobs:
       - name: Build ${{ matrix.runtime }}
         id: srtool_build
         uses: chevdor/srtool-actions@v0.9.2
+        env:
+          BUILD_OPTS: "--features on-chain-release-build"
         with:
           image: paritytech/srtool
           chain: ${{ matrix.runtime }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ dependencies = [
  "cumulus-relay-chain-interface",
  "frame-benchmarking",
  "frame-benchmarking-cli",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system-rpc-runtime-api",
  "frame-try-runtime",
@@ -185,6 +186,7 @@ dependencies = [
  "cumulus-primitives-utility",
  "frame-benchmarking",
  "frame-executive",
+ "frame-metadata-hash-extension",
  "frame-support",
  "frame-system",
  "frame-system-benchmarking",
@@ -5486,6 +5488,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808b50db46293432a45e63bc15ea51e0ab4c0a1647b8eb114e31a3e698dd6fbe"
 dependencies = [
  "hash-db",
+]
+
+[[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
 ]
 
 [[package]]
@@ -11656,6 +11672,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11680,6 +11719,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -13393,13 +13438,22 @@ version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dc993ad871b63fbba60362f3ea86583f5e7e1256e8fdcb3b5b249c9ead354bf"
 dependencies = [
+ "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.14",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ assets-common                              = { version = "0.14.0", default-featu
 frame-benchmarking                         = { version = "35.0.0", default-features = false }
 frame-benchmarking-cli                     = { version = "39.0.0" }
 frame-executive                            = { version = "35.0.0", default-features = false }
+frame-metadata-hash-extension              = { version = "0.3.0", default-features = false }
 frame-support                              = { version = "35.0.0", default-features = false }
 frame-system                               = { version = "35.0.0", default-features = false }
 frame-system-benchmarking                  = { version = "35.0.0", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -117,3 +117,4 @@ try-runtime = [
 	"polkadot-cli/try-runtime",
 	"sp-runtime/try-runtime",
 ]
+metadata-hash = ["ajuna-runtime/metadata-hash"]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,6 +23,7 @@ parity-scale-codec = { workspace = true, features = ["std"] }
 # Substrate
 frame-benchmarking             = { workspace = true, features = ["std"] }
 frame-benchmarking-cli         = { workspace = true }
+frame-metadata-hash-extension  = { workspace = true }
 frame-support                  = { workspace = true, features = ["std"] }
 frame-system-rpc-runtime-api   = { workspace = true, features = ["std"] }
 frame-try-runtime              = { workspace = true, features = ["std"] }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -23,7 +23,7 @@ parity-scale-codec = { workspace = true, features = ["std"] }
 # Substrate
 frame-benchmarking             = { workspace = true, features = ["std"] }
 frame-benchmarking-cli         = { workspace = true }
-frame-metadata-hash-extension  = { workspace = true }
+frame-metadata-hash-extension  = { workspace = true, features = ["std"] }
 frame-support                  = { workspace = true, features = ["std"] }
 frame-system-rpc-runtime-api   = { workspace = true, features = ["std"] }
 frame-try-runtime              = { workspace = true, features = ["std"] }

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,30 +1,22 @@
-// Ajuna Node
-// Copyright (C) 2022 BlogaTech AG
+// Copyright (C) Parity Technologies (UK) Ltd.
+// This file is part of Cumulus.
 
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// This program is distributed in the hope that it will be useful,
+// Substrate is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+// GNU General Public License for more details.
 
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License
+// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
+use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
+
 fn main() {
-	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+	generate_cargo_keys();
+	rerun_if_git_head_changed();
 }
-
-#[cfg(all(feature = "std", feature = "metadata-hash"))]
-fn main() {
-	substrate_wasm_builder::WasmBuilder::init_with_defaults()
-		.enable_metadata_hash("AJUN", 12)
-		.build()
-}
-
-#[cfg(not(feature = "std"))]
-fn main() {}

--- a/node/build.rs
+++ b/node/build.rs
@@ -1,22 +1,30 @@
-// Copyright (C) Parity Technologies (UK) Ltd.
-// This file is part of Cumulus.
+// Ajuna Node
+// Copyright (C) 2022 BlogaTech AG
 
-// Substrate is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-// Substrate is distributed in the hope that it will be useful,
+// This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
+// GNU Affero General Public License for more details.
 
-// You should have received a copy of the GNU General Public License
-// along with Cumulus.  If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-use substrate_build_script_utils::{generate_cargo_keys, rerun_if_git_head_changed};
-
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	generate_cargo_keys();
-	rerun_if_git_head_changed();
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
 }
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("AJUN", 12)
+		.build()
+}
+
+#[cfg(not(feature = "std"))]
+fn main() {}

--- a/runtime/ajuna/Cargo.toml
+++ b/runtime/ajuna/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version.workspace    = true
 
 [build-dependencies]
-substrate-wasm-builder = { workspace = true }
+substrate-wasm-builder = { workspace = true, optional = true }
 
 [dependencies]
 # General
@@ -25,6 +25,7 @@ scale-info         = { workspace = true, features = [ "derive" ] }
 assets-common                              = { workspace = true }
 frame-benchmarking                         = { workspace = true, optional = true }
 frame-executive                            = { workspace = true }
+frame-metadata-hash-extension              = { workspace = true }
 frame-support                              = { workspace = true }
 frame-system                               = { workspace = true }
 frame-system-benchmarking                  = { workspace = true, optional = true }
@@ -118,6 +119,7 @@ std = [
     "cumulus-primitives-utility/std",
     "frame-benchmarking/std",
     "frame-executive/std",
+    "frame-metadata-hash-extension/std",
     "frame-support/std",
     "frame-system-benchmarking/std",
     "frame-system-rpc-runtime-api/std",
@@ -172,6 +174,7 @@ std = [
     "staging-xcm/std",
     "staging-xcm-builder/std",
     "staging-xcm-executor/std",
+    "substrate-wasm-builder",
     # integritee
     "pallet-asset-registry/std",
     "xcm-primitives/std",
@@ -258,3 +261,13 @@ try-runtime = [
     # integritee
     "pallet-asset-registry/try-runtime",
 ]
+
+# Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.
+# This pulls in some dependencies and add compile time, this is why we only do it for
+# production builds.
+metadata-hash = ["substrate-wasm-builder?/metadata-hash"]
+
+# A feature that should be enabled when the runtime should be built for on-chain
+# deployment. Hence, the CI building the release artifact should always enable this
+# feature.
+on-chain-release-build = ["metadata-hash"]

--- a/runtime/ajuna/build.rs
+++ b/runtime/ajuna/build.rs
@@ -14,16 +14,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-#[cfg(feature = "std")]
+#[cfg(all(feature = "std", not(feature = "metadata-hash")))]
 fn main() {
-	substrate_wasm_builder::WasmBuilder::new()
-		.with_current_project()
-		.export_heap_base()
-		.import_memory()
+	substrate_wasm_builder::WasmBuilder::build_using_defaults()
+}
+
+#[cfg(all(feature = "std", feature = "metadata-hash"))]
+fn main() {
+	substrate_wasm_builder::WasmBuilder::init_with_defaults()
+		.enable_metadata_hash("AJUN", 12)
 		.build()
 }
 
-/// The wasm builder is deactivated when compiling
-/// this crate for wasm to speed up the compilation.
 #[cfg(not(feature = "std"))]
 fn main() {}

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -130,6 +130,7 @@ pub type SignedExtra = (
 	frame_system::CheckNonce<Runtime>,
 	frame_system::CheckWeight<Runtime>,
 	pallet_transaction_payment::ChargeTransactionPayment<Runtime>,
+	frame_metadata_hash_extension::CheckMetadataHash<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
Adds the `CheckMetadataHash` signed extension. Computing the metadata hash increases compile time and pulls in quite some dependencies. Hence, the feature is gated behind a `metadata-hash` feature, which in turn is gated behind a new `on-chain-release-build` feature gate.

As the name implies, this `on-chain-release-build` feature should always be enabled for runtimes that are used in production. This PR also adds the flag to our srtool build in the CI.