### PR TITLE
add bootnode for ajuna polkadot parachain

### DIFF
--- a/resources/ajuna/ajuna-raw.json
+++ b/resources/ajuna/ajuna-raw.json
@@ -10,7 +10,8 @@
     "/dns/ajuna.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWRyAHbMPNL7CuQtm987a6iLKftME3eQpVqBC6fUsjWuof",
     "/dns/ajuna.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWLXSQdRNS5EXuhpFYiRKHufRsQtb64t4CYj2ah7zx86jA",
     "/dns/rpc-para.ajuna.network/tcp/30332/p2p/12D3KooWLFfa4J2T3JGZft74q3Wu6kSYHPJHNzLsVhdLPGbAZ9Wf",
-    "/dns/rpc-para.ajuna.network/tcp/30333/ws/p2p/12D3KooWLFfa4J2T3JGZft74q3Wu6kSYHPJHNzLsVhdLPGbAZ9Wf"
+    "/dns/rpc-para.ajuna.network/tcp/30333/ws/p2p/12D3KooWLFfa4J2T3JGZft74q3Wu6kSYHPJHNzLsVhdLPGbAZ9Wf",
+    "/dns/ajuna-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAPXggzmvxX8pefwGMNXDzUwigHEKCmrwZzMpySJbYwUK"
   ],
   "telemetryEndpoints": null,
   "protocolId": "ajuna-polkadot",


### PR DESCRIPTION
## Description

Please describe your pull request and link relevant issues.

- Add a bootnode for ajuna polkadot parachain. 
You can verify with 
```
  <ajuna-node binary> \               
  --chain resources/ajuna/ajuna-raw.json \
  --reserved-only \
  --reserved-nodes=/dns/ajuna-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAPXggzmvxX8pefwGMNXDzUwigHEKCmrwZzMpySJbYwUK
```
