### PR TITLE
v0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ dependencies = [
 
 [[package]]
 name = "ajuna-node"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "ajuna-runtime",
  "async-trait",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "ajuna-runtime"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ authors    = [ "Ajuna Network <https://github.com/ajuna-network>" ]
 edition    = "2021"
 homepage   = "https://ajuna.io"
 repository = "https://github.com/ajuna-network/Ajuna"
-version    = "0.8.3"
+version    = "0.8.4"
 
 [workspace.metadata.psvm]
 version = "polkadot-stable2409-3"

--- a/runtime/ajuna/src/lib.rs
+++ b/runtime/ajuna/src/lib.rs
@@ -230,7 +230,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("ajuna"),
 	impl_name: create_runtime_str!("ajuna"),
 	authoring_version: 1,
-	spec_version: 803,
+	spec_version: 804,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
I would like to have a release with the polkadot-sdk version only. As I consider the next update to be the removal of the relay chain as a dot reserve, and I want that to be an isolated upgrade.