### PR TITLE
[ci] ajuna: switch runtime migration tests to ibp

### DIFF
--- a/.github/workflows/runtimes-matrix.json
+++ b/.github/workflows/runtimes-matrix.json
@@ -3,7 +3,7 @@
     "name": "ajuna",
     "package": "ajuna-runtime",
     "path": "runtime/ajuna-runtime",
-    "uri": "wss://rpc-para.ajuna.network:443"
+    "uri": "wss://ajuna.ibp.network:443"
   },
   {
     "name": "ajuna",


### PR DESCRIPTION
We got a too many requests error on our endpoint, so I am switching it for now.