### PR TITLE
Add Dot on Asset hub reserve for the AssetHub migration and remove the relay chain as a trusted reserve for DOT

### DIFF
--- a/chopsticks/ajuna.yml
+++ b/chopsticks/ajuna.yml
@@ -1,7 +1,6 @@
 # In the future we want to add this config to https://github.com/AcalaNetwork/chopsticks/tree/master/configs.
 # But we should wait until we have the governance pallets included because this will change this config.
 endpoint:
-  - wss://ajuna.api.onfinality.io/public-ws
   - wss://ajuna.public.curie.radiumblock.co/ws
   - wss://ajuna.ibp.network
   - wss://ajuna.dotters.network

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -56,8 +56,8 @@ use staging_xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, Case,
 	DenyReserveTransferToRelayChain, DenyThenTry, DescribeAllTerminal, DescribeFamily,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, FrameTransactionalProcessor,
-	FungiblesAdapter, HashedDescription, NativeAsset, NoChecking, ParentAsSuperuser,
-	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	FungiblesAdapter, HashedDescription, NoChecking, ParentAsSuperuser, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 	TrailingSetTopicAsId, WithComputedOrigin,
 };
@@ -344,8 +344,6 @@ pub type TrustedTeleporters = (Case<AssetHubTrustedTeleporter>,);
 // This is only the xcm config. XCMs transferring assets that are not
 // registered in the AssetRegistry will fail and trap the asset.
 type Reserves = (
-	// We accept native assets in general
-	NativeAsset,
 	// Relay chain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets for which the reserve is asset hub

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -344,7 +344,7 @@ pub type TrustedTeleporters = (Case<AssetHubTrustedTeleporter>,);
 // This is only the xcm config. XCMs transferring assets that are not
 // registered in the AssetRegistry will fail and trap the asset.
 type Reserves = (
-	// We accept native assets in general.
+	// We accept native assets in general
 	NativeAsset,
 	// Relay chain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -35,7 +35,7 @@ use orml_traits::{
 	location::{RelativeReserveProvider, Reserve},
 	parameter_type_with_key,
 };
-use orml_xcm_support::{IsNativeConcrete, MultiNativeAsset};
+use orml_xcm_support::IsNativeConcrete;
 use pallet_xcm::XcmPassthrough;
 use parachains_common::{message_queue::ParaIdToSibling, AssetIdForTrustBackedAssets};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -35,7 +35,7 @@ use orml_traits::{
 	location::{RelativeReserveProvider, Reserve},
 	parameter_type_with_key,
 };
-use orml_xcm_support::IsNativeConcrete;
+use orml_xcm_support::{IsNativeConcrete, MultiNativeAsset};
 use pallet_xcm::XcmPassthrough;
 use parachains_common::{message_queue::ParaIdToSibling, AssetIdForTrustBackedAssets};
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
@@ -53,13 +53,13 @@ use staging_xcm::latest::prelude::*;
 use staging_xcm_builder::CurrencyAdapter;
 use staging_xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, DenyReserveTransferToRelayChain,
-	DenyThenTry, DescribeAllTerminal, DescribeFamily, EnsureXcmOrigin, FixedRateOfFungible,
-	FixedWeightBounds, FrameTransactionalProcessor, FungiblesAdapter, HashedDescription,
-	NativeAsset, NoChecking, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, TrailingSetTopicAsId,
-	WithComputedOrigin,
+	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, Case,
+	DenyReserveTransferToRelayChain, DenyThenTry, DescribeAllTerminal, DescribeFamily,
+	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, FrameTransactionalProcessor,
+	FungiblesAdapter, HashedDescription, NoChecking, ParentAsSuperuser, ParentIsPreset,
+	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
+	TrailingSetTopicAsId, WithComputedOrigin,
 };
 use staging_xcm_executor::{traits::JustTry, XcmExecutor};
 use xcm_primitives::{AsAssetLocation, ConvertedRegisteredAssetId};
@@ -322,13 +322,33 @@ parameter_types! {
 	pub RelayNativePerSecond: (AssetId, u128,u128) = (Location::new(1,Here).into(), AJUN * 70, 0u128);
 	// Weight for one XCM operation.
 	pub UnitWeightCost: Weight = Weight::from_parts(1_000_000u64, DEFAULT_PROOF_SIZE);
+
 	pub const AjunNative: AssetFilter = Wild(AllOf { fun: WildFungible, id: AssetId(Location::here()) });
 	pub AssetHubTrustedTeleporter: (AssetFilter, Location) = (AjunNative::get(), AssetHubLocation::get());
+
+	pub const RelayLocation: Location = Location::parent();
+	pub RelayLocationFilter: AssetFilter = Wild(AllOf {
+		fun: WildFungible,
+		id: AssetId(RelayLocation::get()),
+	});
+
+	/// Dot from Asset Hub
+	pub RelayChainNativeAssetFromAssetHub: (AssetFilter, Location) = (
+		RelayLocationFilter::get(),
+		AssetHubLocation::get()
+	);
 }
 
-pub type TrustedTeleporters = (staging_xcm_builder::Case<AssetHubTrustedTeleporter>,);
+pub type TrustedTeleporters = (Case<AssetHubTrustedTeleporter>,);
 
-pub type Reserves = (NativeAsset, ReserveAssetsFrom<AssetHubLocation>);
+type Reserves = (
+	// Assets bridged from different consensus systems held in reserve on Asset Hub.
+	IsBridgedConcreteAssetFrom<AssetHubLocation>,
+	// Relay chain (DOT) from Asset Hub
+	Case<RelayChainNativeAssetFromAssetHub>,
+	// Assets which the reserve is the same as the origin.
+	MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>,
+);
 
 /// The means for routing XCM messages which are not for local execution into the right message
 /// queues.
@@ -555,4 +575,21 @@ impl orml_xtokens::Config for Runtime {
 	type ReserveProvider = AbsoluteAndRelativeReserve<SelfLocationAbsolute>;
 	type RateLimiter = ();
 	type RateLimiterId = ();
+}
+
+/// Matches foreign assets from a given origin.
+/// Foreign assets are assets bridged from other consensus systems. i.e parents > 1.
+pub struct IsBridgedConcreteAssetFrom<Origin>(PhantomData<Origin>);
+impl<Origin> ContainsPair<Asset, Location> for IsBridgedConcreteAssetFrom<Origin>
+where
+	Origin: Get<Location>,
+{
+	fn contains(asset: &Asset, origin: &Location) -> bool {
+		let loc = Origin::get();
+		&loc == origin &&
+			matches!(
+				asset,
+				Asset { id: AssetId(Location { parents: 2, .. }), fun: Fungibility::Fungible(_) },
+			)
+	}
 }

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -578,20 +578,3 @@ impl orml_xtokens::Config for Runtime {
 	type RateLimiter = ();
 	type RateLimiterId = ();
 }
-
-/// Matches foreign assets from a given origin.
-/// Foreign assets are assets bridged from other consensus systems. i.e parents > 1.
-pub struct IsBridgedConcreteAssetFrom<Origin>(PhantomData<Origin>);
-impl<Origin> ContainsPair<Asset, Location> for IsBridgedConcreteAssetFrom<Origin>
-where
-	Origin: Get<Location>,
-{
-	fn contains(asset: &Asset, origin: &Location) -> bool {
-		let loc = Origin::get();
-		&loc == origin &&
-			matches!(
-				asset,
-				Asset { id: AssetId(Location { parents: 2, .. }), fun: Fungibility::Fungible(_) },
-			)
-	}
-}

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -342,12 +342,10 @@ parameter_types! {
 pub type TrustedTeleporters = (Case<AssetHubTrustedTeleporter>,);
 
 type Reserves = (
-	// Assets bridged from different consensus systems held in reserve on Asset Hub.
-	IsBridgedConcreteAssetFrom<AssetHubLocation>,
 	// Relay chain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
-	// Assets which the reserve is the same as the origin.
-	MultiNativeAsset<AbsoluteAndRelativeReserve<SelfLocationAbsolute>>,
+	// Assets for which the reserve is asset hub
+	ReserveAssetsFrom<AssetHubLocation>,
 );
 
 /// The means for routing XCM messages which are not for local execution into the right message

--- a/runtime/ajuna/src/xcm_config.rs
+++ b/runtime/ajuna/src/xcm_config.rs
@@ -56,8 +56,8 @@ use staging_xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, AllowUnpaidExecutionFrom, Case,
 	DenyReserveTransferToRelayChain, DenyThenTry, DescribeAllTerminal, DescribeFamily,
 	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, FrameTransactionalProcessor,
-	FungiblesAdapter, HashedDescription, NoChecking, ParentAsSuperuser, ParentIsPreset,
-	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
+	FungiblesAdapter, HashedDescription, NativeAsset, NoChecking, ParentAsSuperuser,
+	ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit,
 	TrailingSetTopicAsId, WithComputedOrigin,
 };
@@ -341,7 +341,11 @@ parameter_types! {
 
 pub type TrustedTeleporters = (Case<AssetHubTrustedTeleporter>,);
 
+// This is only the xcm config. XCMs transferring assets that are not
+// registered in the AssetRegistry will fail and trap the asset.
 type Reserves = (
+	// We accept native assets in general.
+	NativeAsset,
 	// Relay chain (DOT) from Asset Hub
 	Case<RelayChainNativeAssetFromAssetHub>,
 	// Assets for which the reserve is asset hub


### PR DESCRIPTION
This adds a new reserve for the future Dot location on Asset Hub according to: https://hackmd.io/@n9QBuDYOQXG-nWCBrwx8YQ/HkYVQFS8ke, and it also removes the relay chain as a trusted reserve for DOT.

### tl;dr
Only allow sending DOT between Asset Hub and Ajuna, but no longer between Polkadot and Ajuna.

### Reasoning
Allowing the DOT to come from two chains can unbalance the parachain sovereign accounts. In this case, it can be that a user wants to send funds back to either Polkadot or Asset hub, but if the reserve account is drained due to being unbalanced, the assets will be burned from our chain, yet the sovereign account fails to send it to the recipient on the destination chain due to missing funds. In this scenario, it is harder to give back the funds to the user and make sure that we don't create too many tokens, and we need to carefully rebalance the parachain accounts.

Hence, it is better to simply disallow sending DOT from the relay chain to our account. In this case, the assets will be trapped on our chain, and we can simply give it back to the user from our parachain sovereign account.

### Follow Up
Move tokens from our parachains sovereign account on Polkadot to our parachains sovereign account on the Asset Hub. This needs to be done **after** this PR lands on our production system.

### Tests
Tested with chopsticks that sending DOT and USDT back and forth still works from asset hub, but fails for Polkadot with the following error:


```
               xcm::contains  TRACE: Case asset: Asset { id: AssetId(Location { parents: 1, interior: Here }), fun: Fungible(100000000000000) }, origin: Location { parents: 1, interior: Here }
             xcm::AssetsFrom  TRACE: prefix: Location { parents: 1, interior: X1([Parachain(1000)]) }, origin: Location { parents: 1, interior: Here }, asset: Asset { id: AssetId(Location { parents: 1, interior: Here }), fun: Fungible(100000000000000) }
                xcm::execute  TRACE: !!! ERROR: UntrustedReserveLocation
                xcm::execute  TRACE: Message executed result=Err(ExecutorError { index: 0, xcm_error: UntrustedReserveLocation, weight: Weight { ref_time: 4000000, proof_size: 4096 } })
         xcm::refund_surplus  TRACE: Refunding surplus total_surplus=Weight { ref_time: 4000000, proof_size: 4096 } total_refunded=Weight { ref_time: 0, proof_size: 0 } current_surplus=Weight { ref_time: 4000000, proof_size: 4096 }
                 xcm::weight  TRACE: FixedRateOfFungible::refund_weight weight: Weight { ref_time: 4000000, proof_size: 4096 }, context: XcmContext { origin: Some(Location { parents: 1, interior: Here }), message_id: [180, 254, 156, 191, 75, 200, 82, 203, 88, 247, 62, 3, 230, 226, 178, 38, 160, 99, 66, 204, 199, 99, 43, 149, 48, 220, 182, 113, 237, 55, 98, 214], topic: None }
                 xcm::weight  TRACE: FixedRateOfFungible::refund_weight weight: Weight { ref_time: 4000000, proof_size: 4096 }, context: XcmContext { origin: Some(Location { parents: 1, interior: Here }), message_id: [180, 254, 156, 191, 75, 200, 82, 203, 88, 247, 62, 3, 230, 226, 178, 38, 160, 99, 66, 204, 199, 99, 43, 149, 48, 220, 182, 113, 237, 55, 98, 214], topic: None }
                 xcm::weight  TRACE: FixedRateOfFungible::refund_weight weight: Weight { ref_time: 4000000, proof_size: 4096 }, context: XcmContext { origin: Some(Location { parents: 1, interior: Here }), message_id: [180, 254, 156, 191, 75, 200, 82, 203, 88, 247, 62, 3, 230, 226, 178, 38, 160, 99, 66, 204, 199, 99, 43, 149, 48, 220, 182, 113, 237, 55, 98, 214], topic: None }
         xcm::refund_surplus  TRACE: total_refunded=Weight { ref_time: 0, proof_size: 0 }
           xcm::post_process  TRACE: Execution failed instruction=0 error=UntrustedReserveLocation original_origin=Location { parents: 1, interior: Here }
        xcm::process-message  TRACE: XCM message execution incomplete, used weight: Weight(ref_time: 1000000, proof_size: 1024), error: UntrustedReserveLocation
```
